### PR TITLE
Added macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -421,3 +421,4 @@ packages/
 # vcpkg manifest mode generated files
 vcpkg_manifest_install_*.log
 /CMakeLists.txt
+build/

--- a/Synapse/CMakeLists.txt
+++ b/Synapse/CMakeLists.txt
@@ -7,16 +7,23 @@ project(Synapse LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Find required packages
+# Find Eigen
 find_package(Eigen3 REQUIRED)
-find_package(Armadillo REQUIRED)
 
-# On macOS, OpenBLAS is installed by Homebrew in a specific location
-if(APPLE)
-    set(OpenBLAS_HOME "/opt/homebrew/opt/openblas")
-    set(OpenBLAS_INCLUDE_DIRS "${OpenBLAS_HOME}/include")
-    set(OpenBLAS_LIBRARIES "${OpenBLAS_HOME}/lib/libopenblas.dylib")
-endif()
+# Resolve Solution Directory (Parent of CMake Directory)
+set(SOLUTION_DIR ${CMAKE_SOURCE_DIR}/..)  
+
+# Include Paths
+include_directories(
+    ${SOLUTION_DIR}/armadillo/include       # Armadillo headers
+    ${SOLUTION_DIR}/vcpkg_installed/x64-windows/include  # VCPKG headers
+)
+
+# Library Paths
+link_directories(
+    ${SOLUTION_DIR}/armadillo/lib           # Armadillo libraries
+    ${SOLUTION_DIR}/OpenBlas                # OpenBLAS libraries
+)
 
 # Source Files
 set(SOURCES 
@@ -40,18 +47,32 @@ set(HEADERS
 # Create Executable
 add_executable(Synapse ${SOURCES} ${HEADERS})
 
-# Link External Libraries
-target_link_libraries(Synapse PRIVATE 
-    Eigen3::Eigen
-    ${ARMADILLO_LIBRARIES}
-    ${OpenBLAS_LIBRARIES}
-)
-
-# Include directories
-target_include_directories(Synapse PRIVATE
-    ${ARMADILLO_INCLUDE_DIRS}
-    ${OpenBLAS_INCLUDE_DIRS}
-)
+# Platform-specific settings
+if(APPLE)
+    # macOS-specific settings
+    set(OpenBLAS_HOME "/opt/homebrew/opt/openblas")
+    set(OpenBLAS_INCLUDE_DIRS "${OpenBLAS_HOME}/include")
+    set(OpenBLAS_LIBRARIES "${OpenBLAS_HOME}/lib/libopenblas.dylib")
+    
+    # Link External Libraries for macOS
+    target_link_libraries(Synapse PRIVATE 
+        Eigen3::Eigen
+        ${SOLUTION_DIR}/armadillo/lib/libarmadillo.dylib
+        ${OpenBLAS_LIBRARIES}
+    )
+    
+    # Include directories for macOS
+    target_include_directories(Synapse PRIVATE
+        ${OpenBLAS_INCLUDE_DIRS}
+    )
+else()
+    # Windows-specific settings
+    target_link_libraries(Synapse PRIVATE 
+        Eigen3::Eigen
+        ${SOLUTION_DIR}/armadillo/lib/armadillo_x64d.lib
+        ${SOLUTION_DIR}/OpenBlas/libopenblas.lib
+    )
+endif()
 
 # Enable Debug Symbols in Debug Mode
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -62,3 +83,8 @@ endif()
 set_target_properties(Synapse PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
+
+# VCPKG Integration (if using)
+if(DEFINED CMAKE_TOOLCHAIN_FILE)
+    message(STATUS "Using VCPKG toolchain: ${CMAKE_TOOLCHAIN_FILE}")
+endif()

--- a/Synapse/CMakeLists.txt
+++ b/Synapse/CMakeLists.txt
@@ -7,20 +7,16 @@ project(Synapse LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Resolve Solution Directory (Parent of CMake Directory)
-set(SOLUTION_DIR ${CMAKE_SOURCE_DIR}/..)  
+# Find required packages
+find_package(Eigen3 REQUIRED)
+find_package(Armadillo REQUIRED)
 
-# Include Paths
-include_directories(
-    ${SOLUTION_DIR}/armadillo/include       # Armadillo headers
-    ${SOLUTION_DIR}/vcpkg_installed/x64-windows/include  # VCPKG headers
-)
-
-# Library Paths
-link_directories(
-    ${SOLUTION_DIR}/armadillo/lib           # Armadillo libraries
-    ${SOLUTION_DIR}/OpenBlas                # OpenBLAS libraries
-)
+# On macOS, OpenBLAS is installed by Homebrew in a specific location
+if(APPLE)
+    set(OpenBLAS_HOME "/opt/homebrew/opt/openblas")
+    set(OpenBLAS_INCLUDE_DIRS "${OpenBLAS_HOME}/include")
+    set(OpenBLAS_LIBRARIES "${OpenBLAS_HOME}/lib/libopenblas.dylib")
+endif()
 
 # Source Files
 set(SOURCES 
@@ -46,8 +42,15 @@ add_executable(Synapse ${SOURCES} ${HEADERS})
 
 # Link External Libraries
 target_link_libraries(Synapse PRIVATE 
-    ${SOLUTION_DIR}/armadillo/lib/armadillo_x64d.lib
-    ${SOLUTION_DIR}/OpenBlas/libopenblas.lib
+    Eigen3::Eigen
+    ${ARMADILLO_LIBRARIES}
+    ${OpenBLAS_LIBRARIES}
+)
+
+# Include directories
+target_include_directories(Synapse PRIVATE
+    ${ARMADILLO_INCLUDE_DIRS}
+    ${OpenBLAS_INCLUDE_DIRS}
 )
 
 # Enable Debug Symbols in Debug Mode
@@ -59,8 +62,3 @@ endif()
 set_target_properties(Synapse PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
-
-# VCPKG Integration (if using)
-if(DEFINED CMAKE_TOOLCHAIN_FILE)
-    message(STATUS "Using VCPKG toolchain: ${CMAKE_TOOLCHAIN_FILE}")
-endif()

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Define the local vcpkg directory within the cloned repository
+VCPKG_DIR="$(dirname "$0")/vcpkg"
+VCPKG_EXE="$VCPKG_DIR/vcpkg"
+
+# Function to print colored output
+print_colored() {
+    local color=$1
+    local message=$2
+    case $color in
+        "yellow") echo -e "\033[1;33m$message\033[0m" ;;
+        "green") echo -e "\033[1;32m$message\033[0m" ;;
+        "red") echo -e "\033[1;31m$message\033[0m" ;;
+        "cyan") echo -e "\033[1;36m$message\033[0m" ;;
+        *) echo "$message" ;;
+    esac
+}
+
+# Check if vcpkg is available in the system
+if command -v vcpkg &> /dev/null; then
+    print_colored "green" "System-wide vcpkg found: $(which vcpkg)"
+elif [ -f "$VCPKG_EXE" ]; then
+    print_colored "green" "Local vcpkg found: $VCPKG_EXE"
+else
+    print_colored "yellow" "vcpkg not found. Installing locally..."
+    
+    # Clone the vcpkg repository
+    print_colored "yellow" "Cloning vcpkg repository..."
+    git clone https://github.com/microsoft/vcpkg.git "$VCPKG_DIR"
+    
+    if [ ! -d "$VCPKG_DIR" ]; then
+        print_colored "red" "Failed to clone vcpkg repository."
+        exit 1
+    fi
+    
+    # Run the bootstrap script to build vcpkg
+    print_colored "yellow" "Bootstrapping vcpkg..."
+    "$VCPKG_DIR/bootstrap-vcpkg.sh"
+    
+    if [ -f "$VCPKG_EXE" ]; then
+        print_colored "green" "vcpkg installation completed successfully."
+        # Add vcpkg to the environment PATH (only for this session)
+        export PATH="$VCPKG_DIR:$PATH"
+        print_colored "green" "vcpkg set for local path env var"
+    else
+        print_colored "red" "vcpkg installation failed."
+        exit 1
+    fi
+
+    print_colored "yellow" "Installing dependencies"
+    vcpkg install
+fi
+
+# Check if CMake is installed
+if ! command -v cmake &> /dev/null; then
+    print_colored "yellow" "CMake not found! Installing using Homebrew..."
+    
+    # Check if Homebrew is installed
+    if ! command -v brew &> /dev/null; then
+        print_colored "yellow" "Installing Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
+    
+    # Install CMake using Homebrew
+    brew install cmake
+    
+    if ! command -v cmake &> /dev/null; then
+        print_colored "red" "CMake installation failed!"
+        exit 1
+    fi
+fi
+
+# Run CMake to list available generators
+print_colored "yellow" "Available CMake Generators:"
+cmake --help | grep -A 50 "Generators"
+
+# Create and switch to build directory
+print_colored "yellow" "Switching to build directory"
+mkdir -p build
+cd build
+
+# Prompt for generator selection
+read -p "Enter the generator from the list above: " selected_generator
+print_colored "cyan" "Selected generator is: $selected_generator"
+
+# Prompt for confirmation
+while true; do
+    read -p "Do you want to continue? (yes/no): " response
+    response=$(echo "$response" | tr '[:upper:]' '[:lower:]' | xargs)
+    
+    if [ "$response" = "yes" ]; then
+        print_colored "green" "Proceeding..."
+        break
+    elif [ "$response" = "no" ]; then
+        print_colored "yellow" "You selected No. Asking again..."
+    else
+        print_colored "red" "Invalid input. Please enter 'yes' or 'no'."
+    fi
+done
+
+# Run CMake configuration
+cmake ../synapse -G "$selected_generator" 
+
+# Run the program
+print_colored "yellow" "Running the program..."
+./bin/Synapse 


### PR DESCRIPTION
This PR adds macOS support to the project by:
     
     - Adding a bootstrap.sh script for macOS users
     - Updating CMakeLists.txt to work with macOS libraries
     - Adding .gitignore to exclude build directory
     
     The changes allow users to build and run the project on macOS using Homebrew for dependencies.