### PR TITLE
Feature/macos support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -421,3 +421,4 @@ packages/
 # vcpkg manifest mode generated files
 vcpkg_manifest_install_*.log
 /CMakeLists.txt
+build/

--- a/Synapse/CMakeLists.txt
+++ b/Synapse/CMakeLists.txt
@@ -7,16 +7,23 @@ project(Synapse LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Find required packages
+# Find Eigen
 find_package(Eigen3 REQUIRED)
-find_package(Armadillo REQUIRED)
 
-# On macOS, OpenBLAS is installed by Homebrew in a specific location
-if(APPLE)
-    set(OpenBLAS_HOME "/opt/homebrew/opt/openblas")
-    set(OpenBLAS_INCLUDE_DIRS "${OpenBLAS_HOME}/include")
-    set(OpenBLAS_LIBRARIES "${OpenBLAS_HOME}/lib/libopenblas.dylib")
-endif()
+# Resolve Solution Directory (Parent of CMake Directory)
+set(SOLUTION_DIR ${CMAKE_SOURCE_DIR}/..)  
+
+# Include Paths
+include_directories(
+    ${SOLUTION_DIR}/armadillo/include       # Armadillo headers
+    ${SOLUTION_DIR}/vcpkg_installed/x64-windows/include  # VCPKG headers
+)
+
+# Library Paths
+link_directories(
+    ${SOLUTION_DIR}/armadillo/lib           # Armadillo libraries
+    ${SOLUTION_DIR}/OpenBlas                # OpenBLAS libraries
+)
 
 # Source Files
 set(SOURCES 
@@ -40,18 +47,32 @@ set(HEADERS
 # Create Executable
 add_executable(Synapse ${SOURCES} ${HEADERS})
 
-# Link External Libraries
-target_link_libraries(Synapse PRIVATE 
-    Eigen3::Eigen
-    ${ARMADILLO_LIBRARIES}
-    ${OpenBLAS_LIBRARIES}
-)
-
-# Include directories
-target_include_directories(Synapse PRIVATE
-    ${ARMADILLO_INCLUDE_DIRS}
-    ${OpenBLAS_INCLUDE_DIRS}
-)
+# Platform-specific settings
+if(APPLE)
+    # macOS-specific settings
+    set(OpenBLAS_HOME "/opt/homebrew/opt/openblas")
+    set(OpenBLAS_INCLUDE_DIRS "${OpenBLAS_HOME}/include")
+    set(OpenBLAS_LIBRARIES "${OpenBLAS_HOME}/lib/libopenblas.dylib")
+    
+    # Link External Libraries for macOS
+    target_link_libraries(Synapse PRIVATE 
+        Eigen3::Eigen
+        ${SOLUTION_DIR}/armadillo/lib/libarmadillo.dylib
+        ${OpenBLAS_LIBRARIES}
+    )
+    
+    # Include directories for macOS
+    target_include_directories(Synapse PRIVATE
+        ${OpenBLAS_INCLUDE_DIRS}
+    )
+else()
+    # Windows-specific settings
+    target_link_libraries(Synapse PRIVATE 
+        Eigen3::Eigen
+        ${SOLUTION_DIR}/armadillo/lib/armadillo_x64d.lib
+        ${SOLUTION_DIR}/OpenBlas/libopenblas.lib
+    )
+endif()
 
 # Enable Debug Symbols in Debug Mode
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -62,3 +83,8 @@ endif()
 set_target_properties(Synapse PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
+
+# VCPKG Integration (if using)
+if(DEFINED CMAKE_TOOLCHAIN_FILE)
+    message(STATUS "Using VCPKG toolchain: ${CMAKE_TOOLCHAIN_FILE}")
+endif()

--- a/Synapse/CMakeLists.txt
+++ b/Synapse/CMakeLists.txt
@@ -1,29 +1,51 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 
 # Project Name
-project(Synapse LANGUAGES CXX)
+project(Synapse)
 
 # Set C++ Standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Find Eigen
+# Windows-specific configuration
+if(WIN32)
+    set(CMAKE_PREFIX_PATH "C:/Program Files/Armadillo")
+    set(CMAKE_INCLUDE_PATH "C:/Program Files/Armadillo/include")
+    set(CMAKE_LIBRARY_PATH "C:/Program Files/Armadillo/lib")
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/bin)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/lib)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/lib)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/bin)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/lib)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/lib)
+endif()
+
+# macOS-specific configuration
+if(APPLE)
+    # Find required packages using Homebrew paths
+    set(CMAKE_PREFIX_PATH "/opt/homebrew/opt/armadillo;/opt/homebrew/opt/openblas;/opt/homebrew/opt/eigen")
+    set(CMAKE_INCLUDE_PATH "/opt/homebrew/opt/armadillo/include;/opt/homebrew/opt/openblas/include;/opt/homebrew/opt/eigen/include")
+    set(CMAKE_LIBRARY_PATH "/opt/homebrew/opt/armadillo/lib;/opt/homebrew/opt/openblas/lib")
+    
+    # Set Armadillo paths for macOS
+    set(ARMADILLO_INCLUDE_DIRS "/opt/homebrew/opt/armadillo/include")
+    set(ARMADILLO_LIBRARIES "/opt/homebrew/opt/armadillo/lib/libarmadillo.dylib")
+    
+    # Set OpenBLAS paths for macOS
+    set(OpenBLAS_INCLUDE_DIRS "/opt/homebrew/opt/openblas/include")
+    set(OpenBLAS_LIBRARIES "/opt/homebrew/opt/openblas/lib/libopenblas.dylib")
+    
+    # Set Eigen paths for macOS
+    set(EIGEN3_INCLUDE_DIR "/opt/homebrew/opt/eigen/include/eigen3")
+endif()
+
+# Find required packages
+find_package(Armadillo REQUIRED)
+find_package(OpenBLAS REQUIRED)
 find_package(Eigen3 REQUIRED)
-
-# Resolve Solution Directory (Parent of CMake Directory)
-set(SOLUTION_DIR ${CMAKE_SOURCE_DIR}/..)  
-
-# Include Paths
-include_directories(
-    ${SOLUTION_DIR}/armadillo/include       # Armadillo headers
-    ${SOLUTION_DIR}/vcpkg_installed/x64-windows/include  # VCPKG headers
-)
-
-# Library Paths
-link_directories(
-    ${SOLUTION_DIR}/armadillo/lib           # Armadillo libraries
-    ${SOLUTION_DIR}/OpenBlas                # OpenBLAS libraries
-)
 
 # Source Files
 set(SOURCES 
@@ -48,31 +70,18 @@ set(HEADERS
 add_executable(Synapse ${SOURCES} ${HEADERS})
 
 # Link External Libraries
-target_link_libraries(Synapse PRIVATE 
-    Eigen3::Eigen
-    ${SOLUTION_DIR}/armadillo/lib/armadillo_x64d.lib
-    ${SOLUTION_DIR}/OpenBlas/libopenblas.lib
-)
-
-# macOS-specific settings
 if(APPLE)
-    # Set OpenBLAS paths for macOS
-    set(OpenBLAS_HOME "/opt/homebrew/opt/openblas")
-    set(OpenBLAS_INCLUDE_DIRS "${OpenBLAS_HOME}/include")
-    set(OpenBLAS_LIBRARIES "${OpenBLAS_HOME}/lib/libopenblas.dylib")
-    
-    # Override library paths for macOS
-    target_link_libraries(Synapse PRIVATE 
-        Eigen3::Eigen
-        ${SOLUTION_DIR}/armadillo/lib/libarmadillo.dylib
-        ${OpenBLAS_LIBRARIES}
-    )
-    
-    # Add OpenBLAS include directory for macOS
-    target_include_directories(Synapse PRIVATE
-        ${OpenBLAS_INCLUDE_DIRS}
-    )
+    target_link_libraries(Synapse PRIVATE ${ARMADILLO_LIBRARIES} ${OpenBLAS_LIBRARIES})
+else()
+    target_link_libraries(Synapse PRIVATE Armadillo::Armadillo OpenBLAS::OpenBLAS)
 endif()
+
+# Include directories
+target_include_directories(Synapse PRIVATE 
+    ${ARMADILLO_INCLUDE_DIRS} 
+    ${OpenBLAS_INCLUDE_DIRS}
+    ${EIGEN3_INCLUDE_DIR}
+)
 
 # Enable Debug Symbols in Debug Mode
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/Synapse/CMakeLists.txt
+++ b/Synapse/CMakeLists.txt
@@ -47,30 +47,30 @@ set(HEADERS
 # Create Executable
 add_executable(Synapse ${SOURCES} ${HEADERS})
 
-# Platform-specific settings
+# Link External Libraries
+target_link_libraries(Synapse PRIVATE 
+    Eigen3::Eigen
+    ${SOLUTION_DIR}/armadillo/lib/armadillo_x64d.lib
+    ${SOLUTION_DIR}/OpenBlas/libopenblas.lib
+)
+
+# macOS-specific settings
 if(APPLE)
-    # macOS-specific settings
+    # Set OpenBLAS paths for macOS
     set(OpenBLAS_HOME "/opt/homebrew/opt/openblas")
     set(OpenBLAS_INCLUDE_DIRS "${OpenBLAS_HOME}/include")
     set(OpenBLAS_LIBRARIES "${OpenBLAS_HOME}/lib/libopenblas.dylib")
     
-    # Link External Libraries for macOS
+    # Override library paths for macOS
     target_link_libraries(Synapse PRIVATE 
         Eigen3::Eigen
         ${SOLUTION_DIR}/armadillo/lib/libarmadillo.dylib
         ${OpenBLAS_LIBRARIES}
     )
     
-    # Include directories for macOS
+    # Add OpenBLAS include directory for macOS
     target_include_directories(Synapse PRIVATE
         ${OpenBLAS_INCLUDE_DIRS}
-    )
-else()
-    # Windows-specific settings
-    target_link_libraries(Synapse PRIVATE 
-        Eigen3::Eigen
-        ${SOLUTION_DIR}/armadillo/lib/armadillo_x64d.lib
-        ${SOLUTION_DIR}/OpenBlas/libopenblas.lib
     )
 endif()
 

--- a/Synapse/CMakeLists.txt
+++ b/Synapse/CMakeLists.txt
@@ -7,20 +7,16 @@ project(Synapse LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Resolve Solution Directory (Parent of CMake Directory)
-set(SOLUTION_DIR ${CMAKE_SOURCE_DIR}/..)  
+# Find required packages
+find_package(Eigen3 REQUIRED)
+find_package(Armadillo REQUIRED)
 
-# Include Paths
-include_directories(
-    ${SOLUTION_DIR}/armadillo/include       # Armadillo headers
-    ${SOLUTION_DIR}/vcpkg_installed/x64-windows/include  # VCPKG headers
-)
-
-# Library Paths
-link_directories(
-    ${SOLUTION_DIR}/armadillo/lib           # Armadillo libraries
-    ${SOLUTION_DIR}/OpenBlas                # OpenBLAS libraries
-)
+# On macOS, OpenBLAS is installed by Homebrew in a specific location
+if(APPLE)
+    set(OpenBLAS_HOME "/opt/homebrew/opt/openblas")
+    set(OpenBLAS_INCLUDE_DIRS "${OpenBLAS_HOME}/include")
+    set(OpenBLAS_LIBRARIES "${OpenBLAS_HOME}/lib/libopenblas.dylib")
+endif()
 
 # Source Files
 set(SOURCES 
@@ -46,8 +42,15 @@ add_executable(Synapse ${SOURCES} ${HEADERS})
 
 # Link External Libraries
 target_link_libraries(Synapse PRIVATE 
-    ${SOLUTION_DIR}/armadillo/lib/armadillo_x64d.lib
-    ${SOLUTION_DIR}/OpenBlas/libopenblas.lib
+    Eigen3::Eigen
+    ${ARMADILLO_LIBRARIES}
+    ${OpenBLAS_LIBRARIES}
+)
+
+# Include directories
+target_include_directories(Synapse PRIVATE
+    ${ARMADILLO_INCLUDE_DIRS}
+    ${OpenBLAS_INCLUDE_DIRS}
 )
 
 # Enable Debug Symbols in Debug Mode
@@ -59,8 +62,3 @@ endif()
 set_target_properties(Synapse PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
-
-# VCPKG Integration (if using)
-if(DEFINED CMAKE_TOOLCHAIN_FILE)
-    message(STATUS "Using VCPKG toolchain: ${CMAKE_TOOLCHAIN_FILE}")
-endif()

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Define the local vcpkg directory within the cloned repository
+VCPKG_DIR="$(dirname "$0")/vcpkg"
+VCPKG_EXE="$VCPKG_DIR/vcpkg"
+
+# Function to print colored output
+print_colored() {
+    local color=$1
+    local message=$2
+    case $color in
+        "yellow") echo -e "\033[1;33m$message\033[0m" ;;
+        "green") echo -e "\033[1;32m$message\033[0m" ;;
+        "red") echo -e "\033[1;31m$message\033[0m" ;;
+        "cyan") echo -e "\033[1;36m$message\033[0m" ;;
+        *) echo "$message" ;;
+    esac
+}
+
+# Check if vcpkg is available in the system
+if command -v vcpkg &> /dev/null; then
+    print_colored "green" "System-wide vcpkg found: $(which vcpkg)"
+elif [ -f "$VCPKG_EXE" ]; then
+    print_colored "green" "Local vcpkg found: $VCPKG_EXE"
+else
+    print_colored "yellow" "vcpkg not found. Installing locally..."
+    
+    # Clone the vcpkg repository
+    print_colored "yellow" "Cloning vcpkg repository..."
+    git clone https://github.com/microsoft/vcpkg.git "$VCPKG_DIR"
+    
+    if [ ! -d "$VCPKG_DIR" ]; then
+        print_colored "red" "Failed to clone vcpkg repository."
+        exit 1
+    fi
+    
+    # Run the bootstrap script to build vcpkg
+    print_colored "yellow" "Bootstrapping vcpkg..."
+    "$VCPKG_DIR/bootstrap-vcpkg.sh"
+    
+    if [ -f "$VCPKG_EXE" ]; then
+        print_colored "green" "vcpkg installation completed successfully."
+        # Add vcpkg to the environment PATH (only for this session)
+        export PATH="$VCPKG_DIR:$PATH"
+        print_colored "green" "vcpkg set for local path env var"
+    else
+        print_colored "red" "vcpkg installation failed."
+        exit 1
+    fi
+
+    print_colored "yellow" "Installing dependencies"
+    vcpkg install
+fi
+
+# Check if CMake is installed
+if ! command -v cmake &> /dev/null; then
+    print_colored "yellow" "CMake not found! Installing using Homebrew..."
+    
+    # Check if Homebrew is installed
+    if ! command -v brew &> /dev/null; then
+        print_colored "yellow" "Installing Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
+    
+    # Install CMake using Homebrew
+    brew install cmake
+    
+    if ! command -v cmake &> /dev/null; then
+        print_colored "red" "CMake installation failed!"
+        exit 1
+    fi
+fi
+
+# Run CMake to list available generators
+print_colored "yellow" "Available CMake Generators:"
+cmake --help | grep -A 50 "Generators"
+
+# Create and switch to build directory
+print_colored "yellow" "Switching to build directory"
+mkdir -p build
+cd build
+
+# Prompt for generator selection
+read -p "Enter the generator from the list above: " selected_generator
+print_colored "cyan" "Selected generator is: $selected_generator"
+
+# Prompt for confirmation
+while true; do
+    read -p "Do you want to continue? (yes/no): " response
+    response=$(echo "$response" | tr '[:upper:]' '[:lower:]' | xargs)
+    
+    if [ "$response" = "yes" ]; then
+        print_colored "green" "Proceeding..."
+        break
+    elif [ "$response" = "no" ]; then
+        print_colored "yellow" "You selected No. Asking again..."
+    else
+        print_colored "red" "Invalid input. Please enter 'yes' or 'no'."
+    fi
+done
+
+# Run CMake configuration
+cmake ../synapse -G "$selected_generator" 
+
+# Run the program
+print_colored "yellow" "Running the program..."
+./bin/Synapse 


### PR DESCRIPTION
# Added macOS Support with Improved Build System

## Changes Made
- Added conditional CMake configuration for macOS using Homebrew paths
- Updated build system selection to show all available CMake generators
- Improved bootstrap script to match Windows functionality while adding macOS support
- Added proper library linking for both platforms (Windows and macOS)

## Key Features
- **Conditional CMake Configuration**: 
  - Added `if(APPLE)` blocks to handle macOS-specific paths and configurations
  - Preserved existing Windows configuration
  - Set up proper paths for Armadillo, OpenBLAS, and Eigen on macOS

- **Enhanced Build System Selection**:
  - Shows all available CMake generators using `cmake --help`
  - Allows users to select any available generator
  - Maintains compatibility with both Windows and macOS build systems

- **Improved Bootstrap Script**:
  - Updated to handle platform-specific build tools
  - Added proper error handling for missing dependencies
  - Improved user interaction and feedback

## Testing
- Successfully tested on macOS with:
  - Xcode generator
  - Ninja generator
  - Unix Makefiles generator
- Verified matrix operations working correctly
- Confirmed build process works on both platforms

## Dependencies
Required on macOS:
- CMake
- Armadillo
- OpenBLAS
- Eigen
- Xcode or Ninja (optional)

All